### PR TITLE
Use double dollar signs for MathJax for safer delimeters

### DIFF
--- a/source/_includes/custom/head.mathjax.html
+++ b/source/_includes/custom/head.mathjax.html
@@ -8,7 +8,7 @@
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
     tex2jax: {
-      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+      inlineMath: [ ['$$','$$'], ["\\(","\\)"] ],
       processEscapes: true
     }
   });


### PR DESCRIPTION
See discussion at: http://meta.electronics.stackexchange.com/questions/440/tex-delimiters-should-be-changed
