### PR TITLE
Update screenshot URL in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,4 +22,4 @@ You also need to add nav.html to default asides in *_config.yml*
 default_asides: [asides/nav.html, asides/recent_posts.html ....
 ```
 
-![Oct2 screenshot](https://raw.github.com/bijumon/oct2/master/oct2.png)
+![Oct2 screenshot](https://raw.github.com/bijumon/oct2/master/source/images/oct2.png)


### PR DESCRIPTION
The image was recently moved to `source/images` but the URL in the README still points to the old location.
