### PR TITLE
changed layout to null not nil to follow jekyll standards

### DIFF
--- a/source/_includes/custom/category_feed.xml
+++ b/source/_includes/custom/category_feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/source/atom.xml
+++ b/source/atom.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
According to this jekyll issue:

https://github.com/jekyll/jekyll/issues/2712

changing this removes the warning: 

 Build Warning: Layout 'nil' requested in categories/esxi/atom.xml does not exist.
